### PR TITLE
Added files which allows using the FirebirdSqlPersistenceFactory duri…

### DIFF
--- a/src/NEventStore/FirebirdSqlPersistenceWireup.cs
+++ b/src/NEventStore/FirebirdSqlPersistenceWireup.cs
@@ -1,0 +1,83 @@
+﻿namespace NEventStore
+{
+    using System.Transactions;
+    using System;
+
+    using NEventStore.Logging;
+    using NEventStore.Persistence.Sql;
+    using NEventStore.Serialization;
+
+    /// <summary>
+    /// Class FirebirdSqlPersistenceWireup. Allows the usage of the FirebirdSqlPersistenceFactory which sends differente statements in different commands to the database.
+    /// This is due to a problem with the .NET Provider.
+    /// </summary>
+    public class FirebirdSqlPersistenceWireup: PersistenceWireup
+    {
+        private const int DefaultPageSize = 512;
+        private static readonly ILog Logger = LogFactory.BuildLogger(typeof(SqlPersistenceWireup));
+        private int _pageSize = DefaultPageSize;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FirebirdSqlPersistenceWireup"/> class.
+        /// </summary>
+        /// <param name="wireup">The wireup.</param>
+        /// <param name="connectionFactory">The connection factory.</param>
+        public FirebirdSqlPersistenceWireup(Wireup wireup, IConnectionFactory connectionFactory)
+            : base(wireup)
+        {
+            Container.Register<ISqlDialect>(c => null); // auto-detect
+            Container.Register<IStreamIdHasher>(c => new Sha1StreamIdHasher());
+
+            Container.Register(c => new FirebirdSqlPersistenceFactory(
+                connectionFactory,
+                c.Resolve<ISerialize>(),
+                c.Resolve<ISqlDialect>(),
+                c.Resolve<IStreamIdHasher>(),
+                c.Resolve<TransactionScopeOption>(),
+                _pageSize).Build());
+        }
+
+        /// <summary>
+        /// Withes the dialect.
+        /// </summary>
+        /// <param name="instance">The instance.</param>
+        /// <returns>FirebirdSqlPersistenceWireup.</returns>
+        public virtual FirebirdSqlPersistenceWireup WithDialect(ISqlDialect instance)
+        {
+            Container.Register(instance);
+            return this;
+        }
+
+        /// <summary>
+        /// Pages the every.
+        /// </summary>
+        /// <param name="records">The records.</param>
+        /// <returns>FirebirdSqlPersistenceWireup.</returns>
+        public virtual FirebirdSqlPersistenceWireup PageEvery(int records)
+        {
+            _pageSize = records;
+            return this;
+        }
+
+        /// <summary>
+        /// Withes the stream identifier hasher.
+        /// </summary>
+        /// <param name="instance">The instance.</param>
+        /// <returns>FirebirdSqlPersistenceWireup.</returns>
+        public virtual FirebirdSqlPersistenceWireup WithStreamIdHasher(IStreamIdHasher instance)
+        {
+            Container.Register(instance);
+            return this;
+        }
+
+        /// <summary>
+        /// Withes the stream identifier hasher.
+        /// </summary>
+        /// <param name="getStreamIdHash">The get stream identifier hash.</param>
+        /// <returns>FirebirdSqlPersistenceWireup.</returns>
+        public virtual FirebirdSqlPersistenceWireup WithStreamIdHasher(Func<string, string> getStreamIdHash)
+        {
+            return WithStreamIdHasher(new DelegateStreamIdHasher(getStreamIdHash));
+        }
+    }
+}

--- a/src/NEventStore/FirebirdWireupExtension.cs
+++ b/src/NEventStore/FirebirdWireupExtension.cs
@@ -1,0 +1,31 @@
+﻿namespace NEventStore
+{
+    using NEventStore.Persistence.Sql;
+
+    /// <summary>
+    /// Extensions which allows usign firebird-specific Persistence due to the existing problems with sending more than one statement in a single command.
+    /// </summary>
+    public static class FirebirdWireupExtension
+    {
+        /// <summary>
+        /// Extension method which allows using the FirebirdPersistenceEngine instead of SqlPersistenceEngine.
+        /// This Engine sends statements in different commands.
+        /// </summary>
+        /// <param name="wireup">The wireup.</param>
+        /// <param name="connectionName">Name of the connection.</param>
+        /// <param name="initialize">if set to <c>true</c> [initialize].</param>
+        /// <returns>FirebirdSqlPersistenceWireup.</returns>
+        public static FirebirdSqlPersistenceWireup UsingFirebirdPersistence(this Wireup wireup, string connectionName, bool initialize = false)
+        {
+            var factory = new ConfigurationConnectionFactory(connectionName);
+            FirebirdSqlPersistenceWireup wire = new FirebirdSqlPersistenceWireup(wireup, factory);
+
+            if (initialize)
+            {
+                wire.InitializeStorageEngine();
+            }
+
+            return wire;
+        }
+    }
+}

--- a/src/NEventStore/NEventStore.csproj
+++ b/src/NEventStore/NEventStore.csproj
@@ -108,6 +108,8 @@
     <Compile Include="EventUpconverterWireupExtensions.cs" />
     <Compile Include="ExtensionMethods.cs" />
     <Compile Include="Conversion\IUpconvertEvents.cs" />
+    <Compile Include="FirebirdSqlPersistenceWireup.cs" />
+    <Compile Include="FirebirdWireupExtension.cs" />
     <Compile Include="Guard.cs" />
     <Compile Include="ICheckpoint.cs" />
     <Compile Include="ICommit.cs" />


### PR DESCRIPTION
Added files which allows using the FirebirdSqlPersistenceFactory during the Wireup of the store. Otherwise it is not possible to use it.

You will need these classes whenever you start a project using NES and firebird, otherwise the SqlPersistenceEngine is used instead of FirebirdSqlPersistenceEngine.

